### PR TITLE
✨ Added Scroll Button to Homepage 🚀

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,10 +8,16 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400..900;1,400..900&display=swap" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="./input.css">
 </head>
 <body class="bg-gray-50">
+
+    <button id="scrollBtn" onclick="scrollToTop()">
+        <i class="fas fa-arrow-up fa-lg"></i>
+    </button>
+
     <!-- Navbar -->
     <nav class="bg-white shadow-sm fixed w-full z-50">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -368,5 +374,22 @@
     </footer>
 
     <script type="module" src="/script.js"></script>
+    
+    <script>
+        let scrollBtn = document.getElementById("scrollBtn");
+    
+    window.onscroll = function() {
+        if (document.body.scrollTop > 200 || document.documentElement.scrollTop > 200) {
+            scrollBtn.style.display = "block";
+        } else {
+            scrollBtn.style.display = "none";
+        }
+    };
+    
+    function scrollToTop() {
+        window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+      </script>
+      
 </body>
 </html>

--- a/public/input.css
+++ b/public/input.css
@@ -1049,3 +1049,24 @@ footer .social-links a:hover {
         transition: transform 0.1s ease;
     }
 }
+
+#scrollBtn {
+    position: fixed;
+    bottom: 30px;
+    right: 30px;
+    width: 50px;
+    height: 50px;
+    background-color: #007BFF;
+    color: white;
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+    display: none;
+    font-size: 20px;
+    transition: background-color 0.3s, transform 0.3s;
+    z-index: 1000;
+}
+#scrollBtn:hover {
+    background-color: blue;
+    transform: scale(1.1);
+}


### PR DESCRIPTION
**fixed issue no: #65**

### **Description:**  
In this pull request, I have added a **scroll-to-top button** to the homepage to enhance user experience. The button appears when the user scrolls down **200 pixels** and provides a smooth scrolling effect when clicked.  

### **Changes Implemented:**  
- 📌 **Added a floating scroll button** at the bottom-right corner of the homepage.  
- 🎨 **Styled the button** with a blue background and a hovering effect that changes it to dark blue with a slight scale-up animation.  
- 🎯 **Integrated Font Awesome icon** for better visual representation.  
- ⚡ **Implemented smooth scrolling** for a better user experience.  
- 📜 **JavaScript functionality added** to dynamically show and hide the button based on scroll position.  

This feature improves navigation, allowing users to return to the top of the page quickly without excessive scrolling.

**preview**

---

![Screenshot 2025-01-31 132224](https://github.com/user-attachments/assets/72027323-c46f-4ad8-8619-993c02d9d412)

---