### PR TITLE
Fix signup input label overlap and spacing issue

### DIFF
--- a/public/auth/signup.html
+++ b/public/auth/signup.html
@@ -29,7 +29,7 @@
         width: 100%;
         border: 0;
         border-bottom: 2px solid #e5e7eb;
-        padding: 0.15rem 0;
+        padding: 0.75rem 0 0.25rem;
         font-size: 1rem;
         color: #1f2937;
         background: transparent;
@@ -43,7 +43,7 @@
       .floating-label {
         position: absolute;
         left: 0;
-        top: 0.75rem;
+        top: 0.5rem;
         font-size: 1rem;
         color: #9ca3af;
         transition: all 0.2s ease-out;

--- a/src/auth/signup.html
+++ b/src/auth/signup.html
@@ -108,7 +108,7 @@
         width: 100%;
         border: 0;
         border-bottom: 2px solid #e5e7eb;
-        padding: 0.15rem 0;
+        padding: 0.75rem 0 0.25rem;
         font-size: 1rem;
         color: #1f2937;
         background: transparent;
@@ -122,7 +122,7 @@
       .floating-label {
         position: absolute;
         left: 0;
-        top: 0.75rem;
+        top: 0.5rem;
         font-size: 1rem;
         color: #9ca3af;
         transition: all 0.2s ease-out;


### PR DESCRIPTION
### What was fixed
- Resolved overlapping of floating labels with input underline on the Signup page
- Fixed spacing inconsistency visible when running the app via npm start

### Root cause
- The issue appeared only in the spacing of the input-fields and floating-label .

### Changes made
- Adjusted input padding and floating label positioning
- Ensured consistent rendering across local dev and full app build

#107 





<img width="1913" height="954" alt="Screenshot 2026-01-24 001350" src="https://github.com/user-attachments/assets/728f7288-bef5-4187-836c-ad3223ead76e" />
